### PR TITLE
score_threshold fix in _get_detections

### DIFF
--- a/keras_retinanet/utils/eval.py
+++ b/keras_retinanet/utils/eval.py
@@ -100,7 +100,7 @@ def _get_detections(generator, model, score_threshold=0.05, max_detections=100, 
 
         if save_path is not None:
             draw_annotations(raw_image, generator.load_annotations(i), label_to_name=generator.label_to_name)
-            draw_detections(raw_image, image_boxes, image_scores, image_labels, label_to_name=generator.label_to_name)
+            draw_detections(raw_image, image_boxes, image_scores, image_labels, label_to_name=generator.label_to_name, score_threshold=score_threshold)
 
             cv2.imwrite(os.path.join(save_path, '{}.png'.format(i)), raw_image)
 


### PR DESCRIPTION
draw_detections (l.103) was called without its optionnal parameter score_threshold. Effectiveley ignoring the score_threshold passed _get_detections when drawing bounding boxes